### PR TITLE
Add process stats from /proc/PID/stats

### DIFF
--- a/hightop/main.cpp
+++ b/hightop/main.cpp
@@ -4,6 +4,7 @@
 #include <ftxui/component/component.hpp>
 #include <ftxui/component/screen_interactive.hpp>
 #include <iostream>
+#include <string>
 #include <vector>
 
 #include "hightop/procs.h"
@@ -18,14 +19,15 @@ std::vector<std::vector<std::string>> get_processes() {
     procs.end(),
     std::back_inserter(rows),
     [](const auto& proc){
+      const auto& stats = proc.get_stats();
       return std::vector<std::string>({
         std::to_string(proc.get_pid()),
-        proc.get_niceness().has_value() ? std::to_string(proc.get_niceness().value()) : "",
-        proc.get_priority().has_value() ? std::to_string(proc.get_priority().value()) : "",
-        proc.get_virtual_memory().has_value() ? std::to_string(proc.get_virtual_memory().value()) : "",
-        proc.get_resident_memory().has_value() ? std::to_string(proc.get_resident_memory().value()) : "",
-        proc.get_state().has_value() ? proc.get_state().value() : "",
-        proc.get_command().value_or(""),
+        std::to_string(stats.nice),
+        std::to_string(stats.priority),
+        std::to_string(stats.vsize),
+        std::to_string(stats.rss),
+        std::to_string(stats.state),
+        stats.comm
       });
     });
   return rows;

--- a/hightop/main.cpp
+++ b/hightop/main.cpp
@@ -9,33 +9,41 @@
 #include "hightop/procs.h"
  
 
-std::vector<std::vector<ftxui::Element>> get_processes() {
-  auto procs = hightop::get_processes();
-  std::vector<std::vector<ftxui::Element>> rows;
+std::vector<std::vector<std::string>> get_processes() {
+  auto procs = hightop::get_running_processes();
+  std::vector<std::vector<std::string>> rows;
+  rows.push_back({"PID",  "NICE", "PRIO", "VIRT", "RES", "STATE", "COMMAND"});
   std::transform(
     procs.begin(),
     procs.end(),
     std::back_inserter(rows),
     [](const auto& proc){
-      auto name = ftxui::text("PID " + std::to_string(proc.get_pid()));
-      return std::vector<ftxui::Element>({name});
+      return std::vector<std::string>({
+        std::to_string(proc.get_pid()),
+        proc.get_niceness().has_value() ? std::to_string(proc.get_niceness().value()) : "",
+        proc.get_priority().has_value() ? std::to_string(proc.get_priority().value()) : "",
+        proc.get_virtual_memory().has_value() ? std::to_string(proc.get_virtual_memory().value()) : "",
+        proc.get_resident_memory().has_value() ? std::to_string(proc.get_resident_memory().value()) : "",
+        proc.get_state().has_value() ? proc.get_state().value() : "",
+        proc.get_command().value_or(""),
+      });
     });
   return rows;
 }
 
 int main(void) {
   using namespace ftxui;
-  auto status_label = std::string{"Processes: "} + std::to_string(hightop::count_processes());
   auto processes = get_processes();
+  auto status_label = std::string{"Processes: "} + std::to_string(processes.size());
 
   auto renderer = Renderer([&] {
     Table table(processes);
+    table.SelectRow(0).BorderBottom(BorderStyle::DOUBLE);
 
     return vbox({
       hbox({
         text(status_label),
-      }),
-      separator(),
+      }) | border,
       vbox({
         table.Render() | vscroll_indicator | frame | flex
       }) | flex,
@@ -50,7 +58,7 @@ int main(void) {
   std::thread refresh_ui([&] {
     while (refresh_ui_continue) {
       using namespace std::chrono_literals;
-      std::this_thread::sleep_for(0.05s);
+      std::this_thread::sleep_for(0.2s);
       screen.Post([&]{processes = get_processes(); });
       // After updating the state, request a new frame to be drawn. This is done
       // by simulating a new "custom" event to be handled.

--- a/libhightop/procs.cpp
+++ b/libhightop/procs.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <vector>
+#include <fstream>
 
 #include <sys/sysinfo.h>
 
@@ -25,18 +26,96 @@ bool is_pid_directory(const std::string& entry) {
   return true;
 }
 
-std::vector<Process> get_processes() {
+std::string read_line_from_file(const std::filesystem::path& path) {
+  std::ifstream file{path};
+  std::string contents;
+  std::getline(file, contents);
+  return contents;
+}
+
+ProcessStats read_process_stats(const std::filesystem::path& path) {
+  // return a struct instance with tokens pared from the first line of path
+  ProcessStats stats;
+  std::ifstream stat_file{path};
+  stat_file >> stats.pid;
+  stat_file >> stats.comm;
+  stat_file >> stats.state;
+  stat_file >> stats.ppid;
+  stat_file >> stats.pgrp;
+  stat_file >> stats.session;
+  stat_file >> stats.tty_nr;
+  stat_file >> stats.tpgid;
+  stat_file >> stats.flags;
+  stat_file >> stats.minflt;
+  stat_file >> stats.cminflt;
+  stat_file >> stats.majflt;
+  stat_file >> stats.cmajflt;
+  stat_file >> stats.utime;
+  stat_file >> stats.stime;
+  stat_file >> stats.cutime;
+  stat_file >> stats.cstime;
+  stat_file >> stats.priority;
+  stat_file >> stats.nice;
+  stat_file >> stats.num_threads;
+  stat_file >> stats.itrealvalue;
+  stat_file >> stats.starttime;
+  stat_file >> stats.vsize;
+  stat_file >> stats.rss;
+  stat_file >> stats.rsslim;
+  stat_file >> stats.startcode;
+  stat_file >> stats.endcode;
+  stat_file >> stats.startstack;
+  stat_file >> stats.kstkesp;
+  stat_file >> stats.kstkeip;
+  stat_file >> stats.signal;
+  stat_file >> stats.blocked;
+  stat_file >> stats.sigignore;
+  stat_file >> stats.sigcatch;
+  stat_file >> stats.wchan;
+  stat_file >> stats.nswap;
+  stat_file >> stats.cnswap;
+  stat_file >> stats.exit_signal;
+  stat_file >> stats.processor;
+  stat_file >> stats.rt_priority;
+  stat_file >> stats.policy;
+  stat_file >> stats.delayacct_blkio_ticks;
+  stat_file >> stats.guest_time;
+  stat_file >> stats.cguest_time;
+  stat_file >> stats.start_data;
+  stat_file >> stats.end_data;
+  stat_file >> stats.start_brk;
+  stat_file >> stats.arg_start;
+  stat_file >> stats.arg_end;
+  stat_file >> stats.env_start;
+  stat_file >> stats.env_end;
+  stat_file >> stats.exit_code;
+  return stats;
+}
+
+Process::Process(int pid) : pid{pid} {
+  auto procfs_path = std::filesystem::path{"/proc"} / std::to_string(pid);
+  // TODO get owner user id of the procfs_path directory
+  command = read_line_from_file(procfs_path / "cmdline");
+
+  ProcessStats stats = read_process_stats(procfs_path / "stat");
+  niceness = stats.nice;
+  priority = stats.priority;
+  resident_memory = stats.rss;
+  virtual_memory = stats.vsize;
+  state = std::string(1, stats.state);
+}
+
+std::vector<Process> get_running_processes() {
   std::vector<Process> processes;
 
-  for (const auto& path : std::filesystem::directory_iterator("/proc")) {
-    const auto filename = path.path().filename().string();
+  for (const auto& entry : std::filesystem::directory_iterator("/proc")) {
+    const auto filename = entry.path().filename().string();
 
     if (!is_pid_directory(filename)) {
       continue;
     }
 
-    int pid = std::stoi(filename);
-    processes.emplace_back(pid);
+    processes.emplace_back(std::stoi(filename));
   }
 
   return processes;

--- a/libhightop/procs.cpp
+++ b/libhightop/procs.cpp
@@ -94,15 +94,8 @@ ProcessStats read_process_stats(const std::filesystem::path& path) {
 
 Process::Process(int pid) : pid{pid} {
   auto procfs_path = std::filesystem::path{"/proc"} / std::to_string(pid);
-  // TODO get owner user id of the procfs_path directory
   command = read_line_from_file(procfs_path / "cmdline");
-
-  ProcessStats stats = read_process_stats(procfs_path / "stat");
-  niceness = stats.nice;
-  priority = stats.priority;
-  resident_memory = stats.rss;
-  virtual_memory = stats.vsize;
-  state = std::string(1, stats.state);
+  stats = read_process_stats(procfs_path / "stat");
 }
 
 std::vector<Process> get_running_processes() {

--- a/libhightop/procs.h
+++ b/libhightop/procs.h
@@ -78,38 +78,12 @@ class Process {
     std::optional<std::string> get_command() const { return command; }
     void set_command(std::string command) { this->command = std::move(command); }
 
-    std::optional<int> get_niceness() const { return niceness; }
-    void set_niceness(int niceness) { this->niceness = niceness; }
-
-    std::optional<int> get_priority() const { return priority; }
-    void set_priority(int priority) { this->priority = priority; }
-
-    std::optional<int> get_uid() const { return uid; }
-    void set_uid(int uid) { this->uid = uid; }
-
-    std::optional<long> get_virtual_memory() const { return virtual_memory; }
-    void set_virtual_memory(long virtual_memory) { this->virtual_memory = virtual_memory; }
-
-    std::optional<long> get_resident_memory() const { return resident_memory; }
-    void set_resident_memory(long resident_memory) { this->resident_memory = resident_memory; }
-
-    std::optional<long> get_shared_memory() const { return shared_memory; }
-    void set_shared_memory(long shared_memory) { this->shared_memory = shared_memory; }
-
-    std::optional<std::string> get_state() const { return state; }
-    void set_state(std::string state) { this->state = std::move(state); }
+    const ProcessStats& get_stats() const { return stats; }
 
   private:
     int pid;
     std::optional<std::string> command;
-    std::optional<std::string> state;
-    std::optional<int> niceness;
-    std::optional<int> priority;
-    std::optional<int> uid;
-    std::optional<long> virtual_memory;
-    std::optional<long> resident_memory;
-    std::optional<long> shared_memory;
-    std::optional<long> num_threads;
+    ProcessStats stats;
 };
 
 int count_processes();

--- a/libhightop/procs.h
+++ b/libhightop/procs.h
@@ -1,26 +1,118 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <vector>
 
 namespace hightop {
 
+/* Content from /proc/$pid/stat */
+struct ProcessStats {
+  int pid;
+  std::string comm;
+  char state;
+  int ppid;
+  int pgrp;
+  int session;
+  int tty_nr;
+  int tpgid;
+  unsigned flags;
+  unsigned long minflt;
+  unsigned long cminflt;
+  unsigned long majflt;
+  unsigned long cmajflt;
+  unsigned long utime;
+  unsigned long stime;
+  long cutime;
+  long cstime;
+  long priority;
+  long nice;
+  long num_threads;
+  long itrealvalue;
+  unsigned long long starttime;
+  unsigned long vsize;
+  long rss;
+  unsigned long rsslim;
+  unsigned long startcode;
+  unsigned long endcode;
+  unsigned long startstack;
+  unsigned long kstkesp;
+  unsigned long kstkeip;
+  unsigned long signal;
+  unsigned long blocked;
+  unsigned long sigignore;
+  unsigned long sigcatch;
+  unsigned long wchan;
+  unsigned long nswap;
+  unsigned long cnswap;
+  int exit_signal;
+  int processor;
+  unsigned rt_priority;
+  unsigned policy;
+  unsigned long long delayacct_blkio_ticks;
+  unsigned long guest_time;
+  long cguest_time;
+  unsigned long start_data;
+  unsigned long end_data;
+  unsigned long start_brk;
+  unsigned long arg_start;
+  unsigned long arg_end;
+  unsigned long env_start;
+  unsigned long env_end;
+  int exit_code;
+};
+
 class Process {
   public:
-    Process(int pid) : pid(pid) {}
+    Process(int pid);
     Process(const Process&) = default;
     Process(Process&&) = default;
     Process& operator=(const Process&) = default;
     Process& operator=(Process&&) = default;
 
-    int get_pid() const { return pid; }
     friend std::ostream& operator<<(std::ostream& os, const Process& dt);
+
+    int get_pid() const { return pid; }
+    void set_pid(int pid) { this->pid = pid; }
+
+    std::optional<std::string> get_command() const { return command; }
+    void set_command(std::string command) { this->command = std::move(command); }
+
+    std::optional<int> get_niceness() const { return niceness; }
+    void set_niceness(int niceness) { this->niceness = niceness; }
+
+    std::optional<int> get_priority() const { return priority; }
+    void set_priority(int priority) { this->priority = priority; }
+
+    std::optional<int> get_uid() const { return uid; }
+    void set_uid(int uid) { this->uid = uid; }
+
+    std::optional<long> get_virtual_memory() const { return virtual_memory; }
+    void set_virtual_memory(long virtual_memory) { this->virtual_memory = virtual_memory; }
+
+    std::optional<long> get_resident_memory() const { return resident_memory; }
+    void set_resident_memory(long resident_memory) { this->resident_memory = resident_memory; }
+
+    std::optional<long> get_shared_memory() const { return shared_memory; }
+    void set_shared_memory(long shared_memory) { this->shared_memory = shared_memory; }
+
+    std::optional<std::string> get_state() const { return state; }
+    void set_state(std::string state) { this->state = std::move(state); }
+
   private:
     int pid;
+    std::optional<std::string> command;
+    std::optional<std::string> state;
+    std::optional<int> niceness;
+    std::optional<int> priority;
+    std::optional<int> uid;
+    std::optional<long> virtual_memory;
+    std::optional<long> resident_memory;
+    std::optional<long> shared_memory;
+    std::optional<long> num_threads;
 };
 
-
 int count_processes();
-std::vector<Process> get_processes();
+std::vector<Process> get_running_processes();
 
 }  // namespace hightop


### PR DESCRIPTION
This is very linux-centric. This is okay for now, but should
be revised to be more platform independent if supporting
more than just linux is desired.